### PR TITLE
fix(view360): preserve UTF-8 text in Razor views

### DIFF
--- a/EPORTAL/Areas/View360/Views/Chatbot/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/Chatbot/Index.cshtml
@@ -1,4 +1,4 @@
-@model List<EPORTAL.ModelsView360.VirtualValidation>
+﻿@model List<EPORTAL.ModelsView360.VirtualValidation>
 @{
     ViewBag.Title = "Cấu hình Chatbot AI";
     Layout = "~/Views/Shared/_Layout.cshtml";

--- a/EPORTAL/Areas/View360/Views/Chatbot/KnowledgeBase.cshtml
+++ b/EPORTAL/Areas/View360/Views/Chatbot/KnowledgeBase.cshtml
@@ -1,4 +1,4 @@
-@model System.Collections.Generic.List<EPORTAL.Common.KnowledgeStore.KnowledgeRow>
+﻿@model System.Collections.Generic.List<EPORTAL.Common.KnowledgeStore.KnowledgeRow>
 @{
     Layout = null;
     var fStatus = (string)ViewBag.FilterStatus;

--- a/EPORTAL/Areas/View360/Views/Dashboard/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/Dashboard/Index.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Dashboard View360";
     Layout = "~/Views/Shared/_Layout.cshtml";
 }

--- a/EPORTAL/Areas/View360/Views/DocumentLibrary/ImportExcel.cshtml
+++ b/EPORTAL/Areas/View360/Views/DocumentLibrary/ImportExcel.cshtml
@@ -1,4 +1,4 @@
-@model EPORTAL.Models.AuthorizationTVValidation
+﻿@model EPORTAL.Models.AuthorizationTVValidation
 
 @using (Html.BeginForm("ImportExcel", "DocumentLibrary", FormMethod.Post, new { enctype = "multipart/form-data", onsubmit = "return myFunction()" }))
 {

--- a/EPORTAL/Areas/View360/Views/ListProject/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListProject/Index.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Dự án 360°";
     Layout = "~/Views/Shared/_LayoutV360Showcase.cshtml";
     // Body class controlled boi page state - viewport-fit cho grid + da chon folder.

--- a/EPORTAL/Areas/View360/Views/ListVirtual/CalibrateIndex.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListVirtual/CalibrateIndex.cshtml
@@ -1,4 +1,4 @@
-@model List<EPORTAL.ModelsView360.VirtualValidation>
+﻿@model List<EPORTAL.ModelsView360.VirtualValidation>
 @{
     ViewBag.Title = "Cấu hình hướng 360°";
     Layout = "~/Views/Shared/_Layout.cshtml";

--- a/EPORTAL/Areas/View360/Views/ListVirtual/Details.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListVirtual/Details.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = Model.Title ?? "Virtual Tour";
 
     // Admin mode (Calibrate / Featured admin) -> dung _Layout.cshtml chung de co

--- a/EPORTAL/Areas/View360/Views/ListVirtual/Featured.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListVirtual/Featured.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Cấu hình khu vực tham quan chính";
     Layout = "~/Views/Shared/_Layout.cshtml";
 

--- a/EPORTAL/Areas/View360/Views/ListVirtual/FeaturedIndex.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListVirtual/FeaturedIndex.cshtml
@@ -1,4 +1,4 @@
-@model List<EPORTAL.ModelsView360.VirtualValidation>
+﻿@model List<EPORTAL.ModelsView360.VirtualValidation>
 @{
     ViewBag.Title = "Cấu hình khu vực tham quan chính";
     Layout = "~/Views/Shared/_Layout.cshtml";

--- a/EPORTAL/Areas/View360/Views/ListVirtual/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListVirtual/Index.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Virtual Tour 360°";
     Layout = "~/Views/Shared/_LayoutV360Showcase.cshtml";
     ViewBag.BodyClass = "v360-sc-fit";  // viewport-fit layout, pager fixed bottom

--- a/EPORTAL/Areas/View360/Views/ListVirtual/Intro.cshtml
+++ b/EPORTAL/Areas/View360/Views/ListVirtual/Intro.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Virtual Tour 360°";
     Layout = "~/Views/Shared/_LayoutV360Showcase.cshtml";
     ViewBag.BodyClass = "v360-sc-fullwidth"; // Intro content full-bleed - bo max-width + padding cua main

--- a/EPORTAL/Areas/View360/Views/MyDocument/ImportExcel.cshtml
+++ b/EPORTAL/Areas/View360/Views/MyDocument/ImportExcel.cshtml
@@ -1,4 +1,4 @@
-@model EPORTAL.Models.NhanVienView
+﻿@model EPORTAL.Models.NhanVienView
 
 @using (Html.BeginForm("ImportExcel", "MyDocument", FormMethod.Post, new { enctype = "multipart/form-data", onsubmit = "return myFunction()" }))
 {

--- a/EPORTAL/Areas/View360/Views/Permission/Audit.cshtml
+++ b/EPORTAL/Areas/View360/Views/Permission/Audit.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Rà soát phân quyền";
     Layout = "~/Views/Shared/_Layout.cshtml";
     bool canRevoke = (bool)(ViewBag.CanRevoke ?? false);

--- a/EPORTAL/Areas/View360/Views/Permission/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/Permission/Index.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Quản lý phân quyền";
     Layout = "~/Views/Shared/_Layout.cshtml";
     bool canGrant  = (bool)(ViewBag.CanGrant  ?? false);

--- a/EPORTAL/Areas/View360/Views/Projects/ImportExcel.cshtml
+++ b/EPORTAL/Areas/View360/Views/Projects/ImportExcel.cshtml
@@ -1,4 +1,4 @@
-@model EPORTAL.Models.NhanVienView
+﻿@model EPORTAL.Models.NhanVienView
 
 @using (Html.BeginForm("ImportExcel", "Projects", FormMethod.Post, new { enctype = "multipart/form-data", onsubmit = "return myFunction()" }))
 {

--- a/EPORTAL/Areas/View360/Views/Projects/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/Projects/Index.cshtml
@@ -1,4 +1,4 @@
-@using EPORTAL.Common
+﻿@using EPORTAL.Common
 @using EPORTAL.ModelsView360
 @using PagedList.Mvc
 @{

--- a/EPORTAL/Areas/View360/Views/ProjectsGroup/Create.cshtml
+++ b/EPORTAL/Areas/View360/Views/ProjectsGroup/Create.cshtml
@@ -1,4 +1,4 @@
-@model EPORTAL.ModelsView360.ProjectsGroupValidation
+﻿@model EPORTAL.ModelsView360.ProjectsGroupValidation
 @{
     var parentOpts = ViewBag.ParentOptions as List<SelectListItem> ?? new List<SelectListItem>();
     var currentParent = Model != null && Model.ParentIDGroup.HasValue ? Model.ParentIDGroup.Value.ToString() : "";

--- a/EPORTAL/Areas/View360/Views/ProjectsGroup/Edit.cshtml
+++ b/EPORTAL/Areas/View360/Views/ProjectsGroup/Edit.cshtml
@@ -1,4 +1,4 @@
-@model EPORTAL.ModelsView360.ProjectsGroupValidation
+﻿@model EPORTAL.ModelsView360.ProjectsGroupValidation
 @{
     var parentOpts = ViewBag.ParentOptions as List<SelectListItem> ?? new List<SelectListItem>();
     var currentParent = Model != null && Model.ParentIDGroup.HasValue ? Model.ParentIDGroup.Value.ToString() : "";

--- a/EPORTAL/Areas/View360/Views/ProjectsGroup/Index.cshtml
+++ b/EPORTAL/Areas/View360/Views/ProjectsGroup/Index.cshtml
@@ -1,4 +1,4 @@
-@using EPORTAL.Common
+﻿@using EPORTAL.Common
 @{
     ViewBag.Title = "Quản lý nhóm dự án";
     Layout = "~/Views/Shared/_Layout.cshtml";

--- a/EPORTAL/Areas/View360/Views/Video/ImportExcel.cshtml
+++ b/EPORTAL/Areas/View360/Views/Video/ImportExcel.cshtml
@@ -1,4 +1,4 @@
-@model EPORTAL.Models.VideoView
+﻿@model EPORTAL.Models.VideoView
 
 @using (Html.BeginForm("ImportExcel", "Video", FormMethod.Post, new { enctype = "multipart/form-data", onsubmit = "return myFunction()" }))
 {

--- a/EPORTAL/Areas/View360/Views/Virtual/ImportExcel.cshtml
+++ b/EPORTAL/Areas/View360/Views/Virtual/ImportExcel.cshtml
@@ -1,4 +1,4 @@
-
+﻿
 @model EPORTAL.Models.NhanVienView
 
 @using (Html.BeginForm("ImportExcel", "Virtual", FormMethod.Post, new { enctype = "multipart/form-data", onsubmit = "return myFunction()" }))

--- a/EPORTAL/Views/Shared/_LayoutV360Showcase.cshtml
+++ b/EPORTAL/Views/Shared/_LayoutV360Showcase.cshtml
@@ -1,4 +1,4 @@
-@using EPORTAL.Models
+﻿@using EPORTAL.Models
 <!DOCTYPE html>
 <html lang="vi">
 <head>


### PR DESCRIPTION
Add UTF-8 BOM markers to View360 Razor files so production compiles Vietnamese literals with the correct encoding.