### PR TITLE
feat(view360): harden handling of OpenAI/VBee responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,14 @@ CHATBOT_VBEE_ASYNC_MAX_CHARS=4000
 # So giay toi da poll VBee async cho 1 cau (mac dinh 60, kep 15..120)
 CHATBOT_VBEE_ASYNC_POLL_SECONDS=60
 
+# === Chatbot - BAO VE response tu dich vu ngoai (ExternalContentGuard) ===
+# Allowlist host cho audioLink VBee tra ve (csv suffix, vd "vbee.vn,vbee.ai").
+# KHONG set -> chi ap guard chung: bat buoc HTTPS + chan link tro ve IP noi bo (SSRF).
+# Set khi muon siet chat (luu y: neu VBee phat audio qua CDN khac domain thi phai them vao day).
+#CHATBOT_VBEE_AUDIO_HOSTS=vbee.vn
+# Kich thuoc audio TTS toi da chap nhan tu VBee (bytes, mac dinh 20MB)
+#CHATBOT_TTS_MAX_AUDIO_BYTES=20971520
+
 # === Chatbot - MODEL OpenAI ===
 # Khong set -> default trong code (gpt-4.1-mini cho stream). Set de prod chot 1 model + max tokens.
 CHATBOT_MODEL=gpt-4.1-mini

--- a/EPORTAL/Areas/View360/Controllers/ChatbotController.cs
+++ b/EPORTAL/Areas/View360/Controllers/ChatbotController.cs
@@ -610,7 +610,7 @@ namespace EPORTAL.Areas.View360.Controllers
                         Response.StatusCode = (int)resp.StatusCode;
                         Response.ContentType = "application/json";
                         return Content("{\"error\":\"VBee " + (int)resp.StatusCode + "\",\"detail\":"
-                            + JsonConvert.SerializeObject(err) + "}", "application/json");
+                            + JsonConvert.SerializeObject(ExternalContentGuard.SafeErrorDetail(err)) + "}", "application/json");
                     }
 
                     return await ReturnVbeeTtsAudio(http, resp, "[Speak/VBee]", voiceCode, speed, text);
@@ -691,7 +691,7 @@ namespace EPORTAL.Areas.View360.Controllers
                 Response.StatusCode = (int)resp.StatusCode;
                 Response.ContentType = "application/json";
                 return Content("{\"error\":\"VBee async " + (int)resp.StatusCode + "\",\"detail\":"
-                    + JsonConvert.SerializeObject(respBody) + "}", "application/json");
+                    + JsonConvert.SerializeObject(ExternalContentGuard.SafeErrorDetail(respBody)) + "}", "application/json");
             }
 
             var j = JObject.Parse(respBody);
@@ -701,7 +701,7 @@ namespace EPORTAL.Areas.View360.Controllers
                 Response.StatusCode = 502;
                 Response.ContentType = "application/json";
                 return Content("{\"error\":\"VBee async response missing requestId\",\"detail\":"
-                    + JsonConvert.SerializeObject(respBody) + "}", "application/json");
+                    + JsonConvert.SerializeObject(ExternalContentGuard.SafeErrorDetail(respBody)) + "}", "application/json");
             }
 
             int maxPollSeconds = ChatbotConfig.GetInt("CHATBOT_VBEE_ASYNC_POLL_SECONDS", "Chatbot.VbeeAsyncPollSeconds", 60);
@@ -733,12 +733,28 @@ namespace EPORTAL.Areas.View360.Controllers
                              ?? (string)pj["data"]?["audio_link"];
                 if (!string.IsNullOrEmpty(audioLink))
                 {
+                    // Guard SSRF: audioLink tu response ngoai - chi fetch HTTPS toi host public
+                    // (khong cho tro ve IP noi bo/localhost; siet them qua CHATBOT_VBEE_AUDIO_HOSTS).
+                    if (!ExternalContentGuard.IsSafeAudioUrl(audioLink))
+                    {
+                        System.Diagnostics.Debug.WriteLine("[Speak/VBee async] audioLink BI CHAN (SSRF guard): " + audioLink);
+                        Response.StatusCode = 502;
+                        return Content("{\"error\":\"VBee audioLink rejected\"}", "application/json");
+                    }
                     var audioRes = await http.GetAsync(audioLink);
                     var audioBytes = await audioRes.Content.ReadAsByteArrayAsync();
                     if (!audioRes.IsSuccessStatusCode || audioBytes.Length == 0)
                     {
                         Response.StatusCode = 502;
                         return Content("{\"error\":\"VBee audioLink fetch failed\"}", "application/json");
+                    }
+                    // Guard noi dung: phai dung la MP3 (magic bytes) + duoi nguong kich thuoc
+                    // truoc khi cache DB va phat cho moi user.
+                    if (!ExternalContentGuard.IsLikelyMp3(audioBytes))
+                    {
+                        System.Diagnostics.Debug.WriteLine("[Speak/VBee async] bytes KHONG phai MP3 hop le, bo qua. len=" + audioBytes.Length);
+                        Response.StatusCode = 502;
+                        return Content("{\"error\":\"VBee audio invalid\"}", "application/json");
                     }
                     System.Diagnostics.Debug.WriteLine("[Speak/VBee async] OK bytes=" + audioBytes.Length);
                     AudioCacheStore.Save(AudioCacheStore.HashFor(voiceCode, speed, text), voiceCode, speed, text, audioBytes);
@@ -749,7 +765,7 @@ namespace EPORTAL.Areas.View360.Controllers
                     Response.StatusCode = 502;
                     Response.ContentType = "application/json";
                     return Content("{\"error\":\"VBee async failed\",\"detail\":"
-                        + JsonConvert.SerializeObject(pollBody) + "}", "application/json");
+                        + JsonConvert.SerializeObject(ExternalContentGuard.SafeErrorDetail(pollBody)) + "}", "application/json");
                 }
             }
 
@@ -768,6 +784,14 @@ namespace EPORTAL.Areas.View360.Controllers
             if (contentType.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
             {
                 var audio = await resp.Content.ReadAsByteArrayAsync();
+                // Guard noi dung: header noi audio nhung bytes phai dung la MP3 + duoi nguong
+                // kich thuoc -> moi duoc cache DB va phat cho user.
+                if (!ExternalContentGuard.IsLikelyMp3(audio))
+                {
+                    System.Diagnostics.Debug.WriteLine(logPrefix + " bytes KHONG phai MP3 hop le, bo qua. len=" + (audio?.Length ?? 0));
+                    Response.StatusCode = 502;
+                    return Content("{\"error\":\"VBee audio invalid\"}", "application/json");
+                }
                 System.Diagnostics.Debug.WriteLine(logPrefix + " OK direct audio bytes=" + audio.Length);
                 AudioCacheStore.Save(AudioCacheStore.HashFor(voiceCode, speed, text), voiceCode, speed, text, audio);
                 return new FileContentResult(audio, "audio/mpeg");
@@ -787,8 +811,24 @@ namespace EPORTAL.Areas.View360.Controllers
                     + JsonConvert.SerializeObject(respBody) + "}", "application/json");
             }
 
+            // Guard SSRF: audio_link tu response ngoai - chi fetch HTTPS toi host public.
+            if (!ExternalContentGuard.IsSafeAudioUrl(audioLink))
+            {
+                System.Diagnostics.Debug.WriteLine(logPrefix + " audio_link BI CHAN (SSRF guard): " + audioLink);
+                Response.StatusCode = 502;
+                Response.ContentType = "application/json";
+                return Content("{\"error\":\"VBee audio_link rejected\"}", "application/json");
+            }
             var audioRes = await http.GetAsync(audioLink);
             var audioBytes = await audioRes.Content.ReadAsByteArrayAsync();
+            // Guard noi dung: phai dung la MP3 truoc khi cache + phat.
+            if (!audioRes.IsSuccessStatusCode || !ExternalContentGuard.IsLikelyMp3(audioBytes))
+            {
+                System.Diagnostics.Debug.WriteLine(logPrefix + " audio via link KHONG hop le. status=" + (int)audioRes.StatusCode + " len=" + (audioBytes?.Length ?? 0));
+                Response.StatusCode = 502;
+                Response.ContentType = "application/json";
+                return Content("{\"error\":\"VBee audio invalid\"}", "application/json");
+            }
             System.Diagnostics.Debug.WriteLine(logPrefix + " OK via link bytes=" + audioBytes.Length);
             AudioCacheStore.Save(AudioCacheStore.HashFor(voiceCode, speed, text), voiceCode, speed, text, audioBytes);
             return new FileContentResult(audioBytes, "audio/mpeg");
@@ -875,7 +915,7 @@ namespace EPORTAL.Areas.View360.Controllers
                         if (!resp.IsSuccessStatusCode)
                         {
                             System.Diagnostics.Debug.WriteLine("[Transcribe/VBee] " + (int)resp.StatusCode + " " + respBody);
-                            return Json(new { ok = false, error = "VBee " + (int)resp.StatusCode + ": " + TruncateForLog(respBody), debugAudio = debugAudio });
+                            return Json(new { ok = false, error = "VBee " + (int)resp.StatusCode + ": " + ExternalContentGuard.SafeErrorDetail(respBody), debugAudio = debugAudio });
                         }
                         var j = JObject.Parse(respBody);
                         // Tim transcript - thu nhieu field name variations
@@ -888,8 +928,10 @@ namespace EPORTAL.Areas.View360.Controllers
                         if (string.IsNullOrEmpty(transcript))
                         {
                             System.Diagnostics.Debug.WriteLine("[Transcribe/VBee] khong tim thay transcript: " + respBody);
-                            return Json(new { ok = false, error = "Khong tim thay transcript", raw = TruncateForLog(respBody), debugAudio = debugAudio });
+                            return Json(new { ok = false, error = "Khong tim thay transcript", raw = ExternalContentGuard.SafeErrorDetail(respBody), debugAudio = debugAudio });
                         }
+                        // Guard: transcript tu dich vu ngoai - loc ky tu dieu khien/an + cap do dai.
+                        transcript = ExternalContentGuard.SanitizeText(transcript, ExternalContentGuard.MAX_TRANSCRIPT_CHARS);
                         return Json(new { ok = true, transcript = transcript, debugAudio = debugAudio });
                     }
                 }
@@ -1353,8 +1395,12 @@ namespace EPORTAL.Areas.View360.Controllers
                 {
                     var args = JObject.Parse(argsJson ?? "{}");
                     // Tool moi: `scene` = ten chinh xac tu enum. Fallback `query` (tool cu).
-                    var scene = (string)args["scene"] ?? (string)args["query"];
-                    var reason = (string)args["reason"];
+                    // Guard: gia tri tu model - loc ky tu dieu khien/an + cap do dai truoc khi
+                    // dung lam text hien thi / lookup.
+                    var scene = ExternalContentGuard.SanitizeText(
+                        (string)args["scene"] ?? (string)args["query"], ExternalContentGuard.MAX_ACTION_CHARS);
+                    var reason = ExternalContentGuard.SanitizeText(
+                        (string)args["reason"], ExternalContentGuard.MAX_REASON_CHARS);
                     if (string.IsNullOrEmpty(scene)) return;
 
                     // Uu tien lookup ten chinh xac -> uuid; neu lech thi FindSceneByQuery (fuzzy) lam luoi do.
@@ -1376,7 +1422,7 @@ namespace EPORTAL.Areas.View360.Controllers
                         System.Diagnostics.Debug.WriteLine("[AskStream] navigate '" + scene + "' -> " + mUuid + " (" + mName + ")");
 
                         // Bubble text: dung reason; them ten thuc te neu khac
-                        var bubbleText = reason ?? "Đang đưa bạn tới điểm đó.";
+                        var bubbleText = !string.IsNullOrEmpty(reason) ? reason : "Đang đưa bạn tới điểm đó.";
                         if (fullText.Length == 0)
                         {
                             fullText.Append(bubbleText);

--- a/EPORTAL/Common/ChatbotAIClient.cs
+++ b/EPORTAL/Common/ChatbotAIClient.cs
@@ -177,7 +177,10 @@ namespace EPORTAL.Common
                         var message = choice?["message"] as JObject;
                         if (message != null)
                         {
-                            reply.Text = (string)message["content"] ?? "";
+                            // Guard: loc ky tu dieu khien/an + cap do dai truoc khi text di tiep
+                            // (ve client, vao DB log, sang VBee TTS).
+                            reply.Text = ExternalContentGuard.SanitizeText(
+                                (string)message["content"] ?? "", ExternalContentGuard.MAX_REPLY_CHARS);
 
                             // Tool call -> set navigate action
                             var toolCalls = message["tool_calls"] as JArray;
@@ -189,12 +192,17 @@ namespace EPORTAL.Common
                                 if (fnName == "navigate_to_scene")
                                 {
                                     var argsRaw = (string)fn["arguments"];
+                                    // Guard: args qua lon = bat thuong (enum scene + reason ngan) -> bo qua
+                                    if (argsRaw != null && argsRaw.Length > ExternalContentGuard.MAX_TOOL_ARGS_CHARS)
+                                        argsRaw = null;
                                     try
                                     {
                                         var args = JObject.Parse(argsRaw ?? "{}");
                                         // Tool moi dung `scene` (ten chinh xac tu enum); fallback `query` (tool cu).
-                                        var query = (string)args["scene"] ?? (string)args["query"];
-                                        var reason = (string)args["reason"];
+                                        var query = ExternalContentGuard.SanitizeText(
+                                            (string)args["scene"] ?? (string)args["query"], ExternalContentGuard.MAX_ACTION_CHARS);
+                                        var reason = ExternalContentGuard.SanitizeText(
+                                            (string)args["reason"], ExternalContentGuard.MAX_REASON_CHARS);
                                         if (!string.IsNullOrEmpty(query))
                                         {
                                             reply.ActionType   = "navigate";
@@ -328,8 +336,17 @@ namespace EPORTAL.Common
                         using (var reader = new System.IO.StreamReader(stream, Encoding.UTF8))
                         {
                             string line;
+                            int emittedChars = 0;       // tong text da emit -> cap MAX_STREAM_CHARS
+                            long totalReadChars = 0;    // tong du lieu doc tu stream -> chong stream vo han
                             while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
                             {
+                                // Guard: stream bat thuong (qua lon) -> cat, khong de treo worker/ngon RAM.
+                                totalReadChars += line.Length;
+                                if (totalReadChars > 2_000_000)
+                                {
+                                    System.Diagnostics.Debug.WriteLine("[StreamAsync] stream vuot 2MB - cat som");
+                                    break;
+                                }
                                 if (line.Length == 0) continue;
                                 if (!line.StartsWith("data:", StringComparison.Ordinal)) continue;
                                 var data = line.Substring(5).TrimStart();
@@ -352,14 +369,19 @@ namespace EPORTAL.Common
                                 var delta = choices[0]?["delta"] as JObject;
                                 if (delta == null) continue;
 
-                                var content = (string)delta["content"];
-                                if (!string.IsNullOrEmpty(content))
+                                // Guard: sanitize tung delta (loc control/bidi/zero-width) + cap tong text.
+                                var content = ExternalContentGuard.SanitizeText(
+                                    (string)delta["content"], 0);
+                                if (!string.IsNullOrEmpty(content) && emittedChars < ExternalContentGuard.MAX_STREAM_CHARS)
                                 {
+                                    if (emittedChars + content.Length > ExternalContentGuard.MAX_STREAM_CHARS)
+                                        content = content.Substring(0, ExternalContentGuard.MAX_STREAM_CHARS - emittedChars);
+                                    emittedChars += content.Length;
                                     try { onTextDelta?.Invoke(content); }
                                     catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[StreamAsync] onTextDelta err: " + ex.Message); }
                                 }
 
-                                // Tool calls stream theo tung delta - accumulate
+                                // Tool calls stream theo tung delta - accumulate (co cap kich thuoc)
                                 var toolCalls = delta["tool_calls"] as JArray;
                                 if (toolCalls != null && toolCalls.Count > 0)
                                 {
@@ -368,7 +390,8 @@ namespace EPORTAL.Common
                                     var fname = (string)fn?["name"];
                                     if (!string.IsNullOrEmpty(fname)) toolName = fname;
                                     var fargs = (string)fn?["arguments"];
-                                    if (!string.IsNullOrEmpty(fargs)) toolArgsBuf.Append(fargs);
+                                    if (!string.IsNullOrEmpty(fargs) && toolArgsBuf.Length < ExternalContentGuard.MAX_TOOL_ARGS_CHARS)
+                                        toolArgsBuf.Append(fargs);
                                 }
                             }
                         }

--- a/EPORTAL/Common/ExternalContentGuard.cs
+++ b/EPORTAL/Common/ExternalContentGuard.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace EPORTAL.Common
+{
+    /// <summary>
+    /// Lop bao ve tap trung cho RESPONSE tu dich vu ngoai (OpenAI, VBee).
+    /// Nguyen tac: khong tin du lieu tu ben ngoai ke ca khi goi qua HTTPS chinh chu -
+    /// response co the bi compromise (account hack, MITM noi bo, provider loi).
+    ///
+    /// Cac lop bao ve:
+    ///  1. SanitizeText  - loc ky tu dieu khien/an (bidi override, zero-width) + cap do dai
+    ///                     -> chong giau noi dung doc, terminal escape, log injection, DoS text khong lo.
+    ///  2. IsSafeAudioUrl - chan SSRF: audioLink tu VBee chi duoc HTTPS + khong duoc tro ve
+    ///                     IP private/loopback/link-local (ke ca sau DNS resolve).
+    ///                     Tuy chon siet host qua env CHATBOT_VBEE_AUDIO_HOSTS.
+    ///  3. IsLikelyMp3   - magic-byte check: bytes tu VBee phai dung la MP3 truoc khi
+    ///                     cache vao DB va phat cho moi user (chong HTML/script gia dang audio).
+    ///  4. SafeErrorDetail - body loi cua provider truoc khi tra ve client: sanitize + cat ngan.
+    /// </summary>
+    public static class ExternalContentGuard
+    {
+        // ====== Gioi han kich thuoc (chars) cho noi dung text tu model ======
+        public const int MAX_REPLY_CHARS      = 8000;   // 1 cau tra loi non-stream
+        public const int MAX_STREAM_CHARS     = 16000;  // tong text tich luy 1 luot stream
+        public const int MAX_TOOL_ARGS_CHARS  = 4000;   // args JSON cua 1 tool call
+        public const int MAX_TRANSCRIPT_CHARS = 1000;   // transcript STT
+        public const int MAX_ACTION_CHARS     = 200;    // ten scene / query navigate
+        public const int MAX_REASON_CHARS     = 300;    // cau xac nhan navigate
+
+        /// <summary>Gioi han audio TTS (bytes). Default 20MB, override CHATBOT_TTS_MAX_AUDIO_BYTES.</summary>
+        public static int MaxAudioBytes
+        {
+            get
+            {
+                var v = ChatbotConfig.GetInt("CHATBOT_TTS_MAX_AUDIO_BYTES", "Chatbot.TtsMaxAudioBytes", 20 * 1024 * 1024);
+                return Math.Max(64 * 1024, Math.Min(100 * 1024 * 1024, v));
+            }
+        }
+
+        // ==================================================================
+        //  1. TEXT SANITIZE
+        // ==================================================================
+
+        /// <summary>
+        /// Loc text tu dich vu ngoai truoc khi day ve client / luu DB:
+        ///  - bo ky tu dieu khien C0/C1 (giu \r \n \t) -> chong terminal escape / log injection
+        ///  - bo ky tu an: zero-width (U+200B-200F, U+FEFF), bidi override (U+202A-202E, U+2066-2069)
+        ///    -> chong giau text doc / dao chieu hien thi danh lua nguoi dung
+        ///  - cap do dai maxLen (&lt;=0 = khong cap)
+        /// KHONG strip HTML - frontend da escape (escHtml) truoc khi render.
+        /// </summary>
+        public static string SanitizeText(string s, int maxLen)
+        {
+            if (string.IsNullOrEmpty(s)) return s ?? "";
+            var sb = new StringBuilder(Math.Min(s.Length, maxLen > 0 ? maxLen : s.Length));
+            foreach (var ch in s)
+            {
+                if (maxLen > 0 && sb.Length >= maxLen) break;
+                if (ch == '\r' || ch == '\n' || ch == '\t') { sb.Append(ch); continue; }
+                if (ch < 0x20 || ch == 0x7F) continue;                    // C0 control + DEL
+                if (ch >= 0x80 && ch <= 0x9F) continue;                   // C1 control
+                if (ch >= 0x200B && ch <= 0x200F) continue;               // zero-width + LRM/RLM
+                if (ch >= 0x202A && ch <= 0x202E) continue;               // bidi embedding/override
+                if (ch >= 0x2066 && ch <= 0x2069) continue;               // bidi isolate
+                if (ch == 0xFEFF) continue;                               // BOM/zero-width no-break
+                sb.Append(ch);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>Body loi tu provider tra ve client: sanitize + cat 400 ky tu (khong lo noi bo).</summary>
+        public static string SafeErrorDetail(string body)
+        {
+            var s = SanitizeText(body, 400);
+            return s;
+        }
+
+        // ==================================================================
+        //  2. SSRF GUARD cho audioLink (VBee TTS)
+        // ==================================================================
+
+        /// <summary>
+        /// audioLink trong response VBee co duoc phep fetch khong:
+        ///  - bat buoc URL tuyet doi, scheme HTTPS
+        ///  - host khong phai localhost / khong resolve ve IP private, loopback, link-local
+        ///  - neu env CHATBOT_VBEE_AUDIO_HOSTS duoc set (csv suffix, vd "vbee.vn,vbee.ai")
+        ///    thi host con phai khop 1 suffix trong danh sach.
+        /// </summary>
+        public static bool IsSafeAudioUrl(string url)
+        {
+            Uri uri;
+            if (string.IsNullOrEmpty(url) || !Uri.TryCreate(url, UriKind.Absolute, out uri)) return false;
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) return false;
+
+            var host = uri.Host;
+            if (string.IsNullOrEmpty(host)) return false;
+            if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase)) return false;
+            if (host.EndsWith(".local", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith(".internal", StringComparison.OrdinalIgnoreCase)) return false;
+
+            // Allowlist tuy chon (suffix match, csv) - set trong .env khi muon siet chat.
+            var allow = ChatbotConfig.Get("CHATBOT_VBEE_AUDIO_HOSTS", "Chatbot.VbeeAudioHosts", null);
+            if (!string.IsNullOrEmpty(allow))
+            {
+                var ok = false;
+                foreach (var rawSuffix in allow.Split(','))
+                {
+                    var suffix = rawSuffix.Trim().TrimStart('.');
+                    if (suffix.Length == 0) continue;
+                    if (host.Equals(suffix, StringComparison.OrdinalIgnoreCase)
+                        || host.EndsWith("." + suffix, StringComparison.OrdinalIgnoreCase)) { ok = true; break; }
+                }
+                if (!ok)
+                {
+                    System.Diagnostics.Debug.WriteLine("[ExternalContentGuard] audioLink host ngoai allowlist: " + host);
+                    return false;
+                }
+            }
+
+            // Host la IP literal -> check truc tiep
+            IPAddress literal;
+            if (IPAddress.TryParse(host.Trim('[', ']'), out literal))
+                return !IsPrivateOrLocal(literal);
+
+            // Hostname -> resolve DNS, MOI dia chi tra ve phai public
+            try
+            {
+                var addrs = Dns.GetHostAddresses(host);
+                if (addrs == null || addrs.Length == 0) return false;
+                foreach (var a in addrs)
+                    if (IsPrivateOrLocal(a))
+                    {
+                        System.Diagnostics.Debug.WriteLine("[ExternalContentGuard] audioLink resolve ve IP noi bo: " + host + " -> " + a);
+                        return false;
+                    }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[ExternalContentGuard] DNS fail cho audioLink host " + host + ": " + ex.Message);
+                return false; // khong resolve duoc thi cung khong fetch duoc -> tu choi som
+            }
+        }
+
+        private static bool IsPrivateOrLocal(IPAddress ip)
+        {
+            if (ip == null) return true;
+            if (IPAddress.IsLoopback(ip)) return true;
+
+            if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                if (ip.IsIPv6LinkLocal || ip.IsIPv6SiteLocal || ip.IsIPv6Multicast) return true;
+                var b16 = ip.GetAddressBytes();
+                if ((b16[0] & 0xFE) == 0xFC) return true;          // fc00::/7 unique-local
+                if (ip.IsIPv4MappedToIPv6) ip = ip.MapToIPv4();    // check tiep phan IPv4 ben duoi
+                else return false;
+            }
+
+            var b = ip.GetAddressBytes();
+            if (b.Length != 4) return false;
+            if (b[0] == 10) return true;                            // 10.0.0.0/8
+            if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return true; // 172.16.0.0/12
+            if (b[0] == 192 && b[1] == 168) return true;            // 192.168.0.0/16
+            if (b[0] == 169 && b[1] == 254) return true;            // 169.254.0.0/16 (link-local/cloud metadata)
+            if (b[0] == 127) return true;                           // 127.0.0.0/8
+            if (b[0] == 0) return true;                             // 0.0.0.0/8
+            return false;
+        }
+
+        // ==================================================================
+        //  3. AUDIO CONTENT CHECK
+        // ==================================================================
+
+        /// <summary>
+        /// Bytes co dang la MP3 hop le khong (truoc khi cache DB + phat cho user):
+        /// chap nhan header "ID3" hoac MPEG frame sync (0xFF 0xEx/0xFx).
+        /// Chan truong hop VBee/CDN tra ve HTML loi, JSON, hay payload khac gia dang audio.
+        /// </summary>
+        public static bool IsLikelyMp3(byte[] bytes)
+        {
+            if (bytes == null || bytes.Length < 4) return false;
+            if (bytes.Length > MaxAudioBytes) return false;
+            if (bytes[0] == 0x49 && bytes[1] == 0x44 && bytes[2] == 0x33) return true; // "ID3"
+            if (bytes[0] == 0xFF && (bytes[1] & 0xE0) == 0xE0) return true;            // MPEG frame sync
+            return false;
+        }
+    }
+}

--- a/EPORTAL/EPORTAL.csproj
+++ b/EPORTAL/EPORTAL.csproj
@@ -1040,6 +1040,7 @@
     <Compile Include="Common\ServiceHealth.cs" />
     <Compile Include="Common\ChatbotContentStore.cs" />
     <Compile Include="Common\AudioCacheStore.cs" />
+    <Compile Include="Common\ExternalContentGuard.cs" />
     <Compile Include="Common\KnowledgeStore.cs" />
     <Compile Include="Common\OpenAIEmbeddingClient.cs" />
     <Compile Include="Common\ChatbotCurator.cs" />


### PR DESCRIPTION
Add ExternalContentGuard - centralized protection for responses from external services (OpenAI chat/stream, VBee TTS/STT):

- Sanitize model text (strip control/bidi/zero-width chars, cap length) for replies, stream deltas, tool-call scene/reason, STT transcripts
- SSRF guard on VBee audioLink: HTTPS only, block private/loopback IPs (post-DNS), optional host allowlist via CHATBOT_VBEE_AUDIO_HOSTS
- Validate TTS bytes are real MP3 (magic bytes + size cap) before caching to DB and serving to users
- Cap runaway SSE streams (2MB read / 16k chars emitted) and tool-args buffers; sanitize + truncate provider error bodies returned to client